### PR TITLE
Add compatibility for Prisoner Content Hub Backend >= build 53

### DIFF
--- a/ansible/host_vars/pfs-dev-hub-1.uksouth.cloudapp.azure.com
+++ b/ansible/host_vars/pfs-dev-hub-1.uksouth.cloudapp.azure.com
@@ -2,7 +2,8 @@
 
 hub_url: pfs-dev-hub-1.uksouth.cloudapp.azure.com
 #Used for compose override
-drupal_url: http://pfs-dev-hub-1.uksouth.cloudapp.azure.com:11001
+drupal_url: pfs-dev-hub-1.uksouth.cloudapp.azure.com:11001
+drupal_protocol: http
 hub_backend_host: drupal.pfs-dev-hub-1.uksouth.cloudapp.azure.com
 public_crt: ../docker/files/nginx/Dev/Berwyn/san.digital-hub.crt
 private_rsa: ../docker/files/nginx/Dev/Berwyn/san.digital-hub.rsa

--- a/ansible/host_vars/pfs-prod-hub-1.uksouth.cloudapp.azure.com
+++ b/ansible/host_vars/pfs-prod-hub-1.uksouth.cloudapp.azure.com
@@ -2,7 +2,8 @@
 
 hub_url: digital-hub.wli.dpn.gov.uk
 #Used for compose override
-drupal_url: https://digital-hub.wli.dpn.gov.uk
+drupal_url: digital-hub.wli.dpn.gov.uk
+drupal_protocol: https
 hub_backend_host: content.digital-hub.wli.dpn.gov.uk
 private_rsa: ../docker/files/nginx/prod/Wayland/wli.digital-hub.rsa
 app_name: HMP Wayland

--- a/ansible/host_vars/pfs-prod-hub-2.uksouth.cloudapp.azure.com
+++ b/ansible/host_vars/pfs-prod-hub-2.uksouth.cloudapp.azure.com
@@ -2,7 +2,8 @@
 
 hub_url: digital-hub.bwi.dpn.gov.uk
 #Used for compose override
-drupal_url: https://digital-hub.bwi.dpn.gov.uk
+drupal_url: digital-hub.bwi.dpn.gov.uk
+drupal_protocol: https
 hub_backend_host: content.digital-hub.bwi.dpn.gov.uk
 private_rsa: ../docker/files/nginx/prod/Berwyn/san.digital-hub.rsa
 app_name: HMP Berwyn

--- a/ansible/host_vars/pfs-prod-hub-3.uksouth.cloudapp.azure.com
+++ b/ansible/host_vars/pfs-prod-hub-3.uksouth.cloudapp.azure.com
@@ -3,7 +3,8 @@
 hub_url: digital-hub-cw.prisoner.service.justice.gov.uk
 #Used for compose override
 hub_backend_host: content.digital-hub-cw.prisoner.service.justice.gov.uk
-drupal_url: http://digital-hub-cw.prisoner.service.justice.gov.uk
+drupal_url: digital-hub-cw.prisoner.service.justice.gov.uk
+drupal_protocol: http
 app_name: HMP Cookham Wood
 feature_switch: "false"
 nginx_conf: ../docker/files/nginx/template/nginx.conf.http.j2

--- a/ansible/host_vars/pfs-stage-hub-1.uksouth.cloudapp.azure.com
+++ b/ansible/host_vars/pfs-stage-hub-1.uksouth.cloudapp.azure.com
@@ -2,7 +2,8 @@
 
 hub_url: pfs-digital-hub-stage.hmpps.dsd.io
 #Used for compose override
-drupal_url: https://content.pfs-digital-hub-stage.hmpps.dsd.io
+drupal_url: content.pfs-digital-hub-stage.hmpps.dsd.io
+drupal_protocol: https
 hub_backend_host: content.pfs-digital-hub-stage.hmpps.dsd.io
 
 app_name: HMP Berwyn

--- a/ansible/roles/docker/files/docker-compose-override.yml.j2
+++ b/ansible/roles/docker/files/docker-compose-override.yml.j2
@@ -3,8 +3,9 @@ version: "3"
 services:
   hub-be:
     restart: "always"
-    environment:
-      HUB_EXT_FILE_URL: {{ drupal_url }}/sites/default/files
+    environment:      
+      FLYSYSTEM_S3_CNAME: {{ drupal_url }}
+      FILE_PUBLIC_BASE_URL: {{ drupal_protocol }}://{{ drupal_url }}/sites/default/files
     volumes:
       - /mnt/pfs-prod-digital-hub-content-share/hub/sites/default/files:/var/www/html/sites/default/files
 
@@ -21,7 +22,7 @@ services:
       - "APP_NAME={{ app_name }}"
       - "ESTABLISHMENT_NAME={{ establishment_name }}"
       - "NODE_ENV=production"
-      - "DRUPAL_APP_URI={{ drupal_url }}/sites/default/files"
+      - "DRUPAL_APP_URI={{ drupal_protocol }}://{{ drupal_url }}/sites/default/files"
       - "ENABLE_PRISON_SWITCH={{ feature_switch }}"
       - "NOMIS_API_TOKEN=${NOMIS_API_KEY}"
       - "NOMIS_API_ENDPOINT={{ NOMIS_API_ENDPOINT }}"

--- a/ansible/roles/docker/files/docker-compose.yml
+++ b/ansible/roles/docker/files/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - HUB_DB_ENV_MYSQL_USER=hubdb_user
       - HUB_DB_ENV_MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - HUB_DB_PORT_3306_TCP_ADDR=hub-db
-      - HUB_EXT_FILE_URL=http://localhost:11001/sites/default/files
       - PHP_MEMORY_LIMIT=256M
       - PHP_UPLOAD_MAX_FILE_SIZE=500M
       - PHP_POST_MAX_SIZE=500M

--- a/ansible/roles/hub-containers/tasks/main.yml
+++ b/ansible/roles/hub-containers/tasks/main.yml
@@ -117,8 +117,7 @@
       export IMAGE_VERSION
       export MYSQL_USER=hubdb_user
       export MYSQL_ROOT_PASSWORD=$(cat /etc/docker-decomposed-secrets-MYSQL_ROOT_PASSWORD)
-      export MYSQL_PASSWORD=$(cat /etc/docker-decomposed-secrets-MYSQL_PASSWORD)
-      export DRUPAL_URL={{ drupal_url }}
+      export MYSQL_PASSWORD=$(cat /etc/docker-decomposed-secrets-MYSQL_PASSWORD)      
       export APP_NAME="{{ app_name }}"
 
       {% if feature_personalization | bool %}


### PR DESCRIPTION
**Note**
Will leave this PR in draft until when/if we decide to deploy new builds of the Drupal backend to the Azure environments
This includes **breaking** changes for builds < 53 of `prisoner-content-hub-backend`

**Changes**
- Removes `HUB_EXT_FILE_URL` environment variable
- Adds support for `FLYSYSTEM_S3_CNAME` and `FILE_PUBLIC_BASE_URL`
- Splits `drupal_url` in to protocol and CNAME for use in generating new values